### PR TITLE
Hyperlink DOIs to preferred resolver

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ParaView OpenSG-Exporter
 ========================
 
-[![](https://zenodo.org/badge/doi/10.5281/zenodo.10161.png)](http://dx.doi.org/10.5281/zenodo.10161)
+[![](https://zenodo.org/badge/doi/10.5281/zenodo.10161.png)](https://doi.org/10.5281/zenodo.10161)
 
 An ParaView-Exporter-Plugin which allows you to export the entire visible scene to OpenSGs (Version 1.8) binary format.
 


### PR DESCRIPTION
Hello :-)

The DOI Foundation [started recommending a new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). While their URL change may be a bit ironic, it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org) and the old `dx` subdomain is being redirected. So, there is no urgency here.

However, for consistency, this PRs suggests to update all static DOI links accordingly.

Cheers!